### PR TITLE
Small performance improvement

### DIFF
--- a/src/lancer/fixers/comments.py
+++ b/src/lancer/fixers/comments.py
@@ -2,7 +2,7 @@ import logging
 from tokenize import COMMENT
 from random import randint
 from lancer.utils import fix_wrapper
-import pkg_resources
+from pkg_resources import resource_filename
 
 __author__ = "Levi Borodenko"
 __copyright__ = "Levi Borodenko"
@@ -28,8 +28,7 @@ class CommentFixer(object):
         super(CommentFixer, self).__init__()
 
         # Path to lyric file resource
-        self.LYRIC_FILE = pkg_resources.resource_filename(
-            __name__, "../resources/lyrics.txt")
+        self.LYRIC_FILE = resource_filename(__name__, "../resources/lyrics.txt")
 
         # Load lyrics which replace original comments here
         self.LYRICS = None

--- a/src/lancer/fixers/comments.py
+++ b/src/lancer/fixers/comments.py
@@ -31,8 +31,13 @@ class CommentFixer(object):
         self.LYRIC_FILE = pkg_resources.resource_filename(
             __name__, "../resources/lyrics.txt")
 
+        # Load lyrics which replace original comments here
+        self.LYRICS = None
+        with open(self.LYRIC_FILE, 'r') as f:
+            self.LYRICS = f.readlines()
+
         # Number of lyrics
-        self.NUM_LYRICS = sum(1 for line in open(self.LYRIC_FILE))
+        self.NUM_LYRICS = len(self.LYRICS)
 
         # setting name
         self.__name__ = "CommentFixer"
@@ -43,15 +48,11 @@ class CommentFixer(object):
         Gives one of many insightful Pitbull quotes.
         """
 
-        # Open lyrics file and grab a random line
-        with open(self.LYRIC_FILE) as f:
+        # Grab a random line from our lyrics
+        random_index = randint(0, self.NUM_LYRICS - 1)
 
-            random_index = randint(0, self.NUM_LYRICS - 1)
-
-            lyrics = f.readlines()
-
-            # .rstrip to remove trailing whitespace
-            return "# " + lyrics[random_index].rstrip()
+        # .rstrip to remove trailing whitespace
+        return "# " + self.LYRICS[random_index].rstrip()
 
     @fix_wrapper
     def fix(self, tokens):

--- a/src/lancer/fixers/variables.py
+++ b/src/lancer/fixers/variables.py
@@ -3,7 +3,7 @@ from tokenize import NAME, NL, DEDENT, INDENT
 from itertools import tee
 import random
 from lancer.utils import fix_wrapper, window, isbuildin
-import pkg_resources
+from pkg_resources import resource_filename
 
 # import pkg_resources
 
@@ -50,8 +50,7 @@ class VariableFixer(object):
         self.NUM_NOISE_CHAR = 5
 
         # Path to lyric file resource
-        self.SOUNDS_FILE = pkg_resources.resource_filename(
-            __name__, "../resources/sounds.txt")
+        self.SOUNDS_FILE = resource_filename(__name__, "../resources/sounds.txt")
 
         # Load sounds which "enhance" original variable names here
         self.SOUNDS = None

--- a/src/lancer/fixers/variables.py
+++ b/src/lancer/fixers/variables.py
@@ -53,8 +53,13 @@ class VariableFixer(object):
         self.SOUNDS_FILE = pkg_resources.resource_filename(
             __name__, "../resources/sounds.txt")
 
+        # Load sounds which "enhance" original variable names here
+        self.SOUNDS = None
+        with open(self.SOUNDS_FILE, 'r') as f:
+            self.SOUNDS = f.readlines()
+
         # Number of Sounds
-        self.NUM_SOUNDS = sum(1 for line in open(self.SOUNDS_FILE))
+        self.NUM_SOUNDS = len(self.SOUNDS)
 
     def _get_random_noise(self) -> str:
         """[summary]
@@ -87,23 +92,19 @@ class VariableFixer(object):
         We read the animal sounds from /resource/sounds.txt
         """
 
-        # Open sounds file and grab a random line
-        with open(self.SOUNDS_FILE) as f:
+        # Grab a random line from our nice sounds
+        random_index = random.randint(0, self.NUM_SOUNDS - 1)
 
-            random_index = random.randint(0, self.NUM_SOUNDS - 1)
+        # get random sound and strip whitespaces
+        sound = self.SOUNDS[random_index].rstrip()
 
-            sounds = f.readlines()
+        # repeat sound up to 2 times
+        sound_list = [sound] * random.randint(1, 3)
 
-            # get random sound and strip whitespaces
-            sound = sounds[random_index].rstrip()
+        # join them to one string
+        sound = "_".join(sound_list) + "_"
 
-            # repeat sound up to 2 times
-            sound_list = [sound for i in range(random.randint(1, 3))]
-
-            # join them to one string
-            sound = "_".join(sound_list) + "_"
-
-            return sound
+        return sound
 
     def _get_new_name(self, input_name: str):
 


### PR DESCRIPTION
This PR aims to improve a small performance improvement for most cases while yielding large improvement overhead for certain edge cases (e.g. `target` file is dominated by comments). The main point is to read **static** resources from the `resources` folder only once (when fixers are initialized) as opposed to once per method call. This gives a small runtime improvement for common `target` files but can have a larger impact when 

-  `target` files get larger
- `resource` files get larger

## Performance
Test call `time lance -f target.py`, from [fish](https://fishshell.com/) v3.1.0, using [miniconda](https://docs.conda.io/en/latest/miniconda.html) Python3.10)

### Standard
Dummy file with 10k LoC, ~20% comments

Results for current release:
`Executed in  562,17 millis    fish           external `
`   usr time  529,73 millis  532,00 micros  529,20 millis` 
`   sys time   32,08 millis  244,00 micros   31,83 millis` 

Results for this PR:
`Executed in  492,96 millis    fish           external `
`   usr time  452,64 millis  407,00 micros  452,23 millis` 
`   sys time   36,21 millis  189,00 micros   36,02 millis`

### Edge Case
Dummy file with 10k LoC, 100% comments

Results for current release:
`Executed in  327,94 millis    fish           external `
`   usr time  279,19 millis  148,00 micros  279,04 millis `
`   sys time   47,90 millis   68,00 micros   47,84 millis`

Results for this PR:
`Executed in  194,65 millis    fish           external `
`   usr time  182,49 millis  507,00 micros  181,98 millis `
`   sys time   12,10 millis  235,00 micros   11,87 millis`

This could be nice for people who want to `yeet` their 1M LoC, pure-python package using `lance` ;)

P.S. `python setup.py test` is passing