### PR TITLE
Add safe for work lyrics option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ever heard of [Black](https://github.com/psf/black)? This is the opposite.
 A tool to turn your clean python code into a hideous (working) mess.
 
 ## Features
-1. Turn all comments into Pitbull lyrics 💃
+1. Turn all comments into Pitbull lyrics 💃 (or optionally, something safe for work)
 2. Turn all your variable names into a mixture of animal sounds and horribly similar looking characters like "bark_bark_0OO0O". 🐶
 3. Add irritating white spaces. 
 4. Code still runs after all these _improvements_! 👷
@@ -52,7 +52,7 @@ if __name__ == '__main__':
 Simply run `pip install py-lancer` and then use the `lance` command line tool.
 
 ```
-usage: lance [-h] [--version] -f ./FILE_PATH.py [-y]
+usage: lance [-h] [--version] -f ./FILE_PATH.py [-s][-y]
 
 Ever heard of Black? This is the opposite.
 
@@ -61,6 +61,7 @@ optional arguments:
   --version             show program's version number and exit
   -f ./FILE_PATH.py, --file ./FILE_PATH.py
                         Python file to be lance'd.
+  -s, --sfw             Generate comments that are safe for work.
   -y, --yolo            Overwrite original file, lol.
 ```
 

--- a/src/lancer/entry.py
+++ b/src/lancer/entry.py
@@ -47,6 +47,12 @@ def parse_args(args):
         required=True,
         metavar="./FILE_PATH.py")
     parser.add_argument(
+        "-s",
+        "--sfw",
+        dest="sfw",
+        help="Generate comments that are safe for work.",
+        action="store_true")
+    parser.add_argument(
         "-y",
         "--yolo",
         dest="yolo",
@@ -66,7 +72,7 @@ def setup_logging(loglevel):
                         format=logformat, datefmt="%Y-%m-%d %H:%M:%S")
 
 
-def lance(file : Path = "./file.py", yolo : bool = False):
+def lance(file: Path = "./file.py", sfw: bool = False, yolo: bool = False):
     """[summary]
     Takes a file and lances it.
 
@@ -76,14 +82,16 @@ def lance(file : Path = "./file.py", yolo : bool = False):
 
     Keyword Arguments:
         file {Path} -- File to be lanced (default: {"./file.py"})
+        sfw {bool} -- Generate comments that are safe for work if true (default: {False})
         yolo {bool} -- Overwrites original if true (default: {False})
     """
     # turn file into path if not already
     file = Path(file)
 
     # initiate "fixers"
-    variabel_fixer = VariableFixer()
+    variable_fixer = VariableFixer()
     comment_fixer = CommentFixer()
+    comment_fixer.sfw = sfw
 
     # first fix comments
     comment_fixer.fix(file)
@@ -92,7 +100,7 @@ def lance(file : Path = "./file.py", yolo : bool = False):
     fixed_file = comment_fixer.__output__
 
     # applying variable fixer
-    variabel_fixer.fix(fixed_file)
+    variable_fixer.fix(fixed_file)
 
     # if yolo mode is true, substitute original
     if yolo:
@@ -107,7 +115,7 @@ def main(args):
     """
     args = parse_args(args)
 
-    lance(file=args.file, yolo=args.yolo)
+    lance(file=args.file, sfw=args.sfw, yolo=args.yolo)
 
 
 def run():

--- a/src/lancer/fixers/comments.py
+++ b/src/lancer/fixers/comments.py
@@ -27,9 +27,15 @@ class CommentFixer(object):
     def __init__(self):
         super(CommentFixer, self).__init__()
 
-        # Path to lyric file resource
+        # Path to lyric file resources
         self.LYRIC_FILE = pkg_resources.resource_filename(
             __name__, "../resources/lyrics.txt")
+
+        self.SFW_LYRIC_FILE = pkg_resources.resource_filename(
+            __name__, "../resources/sfw_lyrics.txt")
+
+        # Generate safe for work content (False by default)
+        self.sfw = False
 
         # Number of lyrics
         self.NUM_LYRICS = sum(1 for line in open(self.LYRIC_FILE))
@@ -40,11 +46,12 @@ class CommentFixer(object):
     def _get_lyric(self) -> str:
         """Returns a random song lyric.
 
-        Gives one of many insightful Pitbull quotes.
+        By default, gives one of many insightful Pitbull quotes.
+        If self.sfw is True, return lyrics that are safe for work.
         """
-
+        lyric_file = self.SFW_LYRIC_FILE if self.sfw else self.LYRIC_FILE
         # Open lyrics file and grab a random line
-        with open(self.LYRIC_FILE) as f:
+        with open(lyric_file) as f:
 
             random_index = randint(0, self.NUM_LYRICS - 1)
 

--- a/src/lancer/resources/sfw_lyrics.txt
+++ b/src/lancer/resources/sfw_lyrics.txt
@@ -1,0 +1,122 @@
+On top of spaghetti all covered with cheese
+I lost my poor meatball when somebody sneezed
+It rolled off the table, it rolled on the floor
+And then my poor meatball rolled out of the door
+It rolled in the garden and under a bush
+And then my poor meatball was nothing but mush
+The mush was as tasty as tasty could be
+And early next summer it grew to a tree
+The tree was all covered with beautiful moss
+It grew great big meatballs and tomato sauce
+So if you eat spaghetti all covered with cheese
+Hold on to your meatball and don’t ever sneeze
+There was a little turtle his name was tiny Tim
+I put him in the bathtub to see if he could swim
+He drank up all the water, he ate up all the soap
+Now he’s in the bathtub with a bubble in his throat
+Bubble bubble bubble bubble bubble bubble bubble bubble POP!
+If all the raindrops were lemon drops and gumdrops
+So what a rain that would be
+Standing outside with my mouth open wide
+Ah, ah, ah, ah, ah, ah, ah, ah, ah, ah
+Oh, what a rain that would be
+If all the snowflakes were candy bars and milkshakes
+Oh, what a snow that would be
+If all the sunbeams were bubblegum and ice cream
+Oh, what a sun that would be!
+Standing outside, with my mouth open wide
+I’m bringing home my baby bumble bee
+Won’t my Mommy be so proud of me I’m bringing home my baby bumble bee – OUCH!! It stung me!!
+I’m squishin’ up my baby bumble bee
+Won’t my Mommy be so proud of me I’m squishin’ up my baby bumble bee – EW!! What a mess!!
+I’m lickin’ up my baby bumble bee
+Won’t my Mommy be so proud of me I’m lickin’ up my baby bumble bee – ICK!! I feel sick!!
+I’m throwin’ up my baby bumble bee
+Won’t my Mommy be so proud of me I’m throwin’ up my baby bumble bee – OH!! What a mess!!
+I’m wipin’ up my baby bumble bee
+Won’t my Mommy be so proud of me I’m wipin’ up my baby bumble bee – OOPS!! Mommy’s new towel!!
+I’m wringin’ out my baby bumble bee
+Won’t my Mommy be so proud of me I’m wringing out my baby bumble bee – Bye-Bye baby bumble bee!!
+Where is Thumbkin? Here I am! Here I am!
+How are you today, sir? Very well, I thank you
+Run away Run away Run away Run away
+Where is Pointer? Here I am! Here I am!
+Where is Middleman? Here I am! Here I am
+Where is Ringman? Here I am! Here I am!
+Where is Pinkie? Here I am! Here I am!
+Underwear, underwear, send a pair, send a pair, I can wear
+For I left mine lying, on a line a drying
+And now I need them they’re not there
+Underwear, underwear, get a pair, get a pair, anywhere
+The bugle’s blowing, I must be going
+For I’ve got to get there if I have to go there bare
+The cows in the barn go moo moo moo
+moo moo moo moo moo moo moo moo moo moo moo moo
+All day long the ducks in the pond go quack quack quack
+quack quack quack quack quack quack
+All day long the pigs in the pen go oink oink oink
+oink oink oink oink oink oink oink oink oink oink
+The pigs in the barn go oink oink oink
+The sheep in the field go baa baa baa
+baa baa baa baa baa baa
+One, two, three, four, five
+Once I caught a fish alive
+Six, seven, eight, nine, ten
+Then I let it go again
+Why did you let it go?
+Because it bit my finger so
+Which finger did it bite?
+The little finger on my right!
+Open them, shut them (open and shut fists)
+Give a little clap
+Lay them in your lap
+Creep them, creep them,
+Creep them, creep them
+Right up to your chin (walk hands up body to chin)
+Open wide your little mouth but do not put them in
+Roll them, roll them, roll them, roll them just like this
+Shake them, shake them
+Blow a little kiss!
+One, two, buckle my shoe
+Three, four, shut the door
+Five, six, pick up sticks
+Seven, eight, lay them straight
+Nine, ten, begin again
+Now everybody sing with me
+Okay everybody, one more time
+Nine, ten, that’s the end
+That’s the end I did it
+I have ten little fingers
+and they all belong to me I can make them do things
+Do you want to see?
+I can close them up tight
+I can open them wide
+I can put them together
+I can make them hide
+I can make them fly high
+I can make them go low
+I can fold them like this and hold them just so
+Hickory dickory dock
+The mouse went up the clock
+The clock struck one
+The mouse went down
+Tick tock, tick tock, tick tock, tick tock
+Teddy Bear Teddy Bear touch the ground
+If you’re an elephant and you know it stomp your feet
+If you’re a monkey and you know it jump up and down
+If you’re a crocodile and you know it snap your jaws
+If you’re a lion and you know it give a roar
+Barney is a dinosaur from our imagination
+And when he's tall he's what we call a dinosaur sensation
+Barney's friends are big and small
+They come from lots of places
+After school they meet to play
+And sing with happy faces
+Barney shows us lots of things
+Like how to play pretend
+ABC's, and 123's
+And how to be a friend
+Barney comes to play with us
+Whenever we may need him
+Barney can be your friend too
+If you just make-believe him

--- a/tests/test_CommentFixer.py
+++ b/tests/test_CommentFixer.py
@@ -80,3 +80,21 @@ class TestCommentFixer(object):
         assert lyric[:2] == "# "
 
         assert self.fixer.NUM_LYRICS > 100
+
+    def test_get_sfw_lyric(self):
+        """Test random sfw lyric generation.
+        """
+        self.fixer.sfw = True
+        lyric = self.fixer._get_lyric()
+
+        assert isinstance(lyric, str)
+        assert len(lyric) > 2
+
+        another_lyric = self.fixer._get_lyric()
+
+        assert lyric != another_lyric
+
+        # make sure comment starts with "# "
+        assert lyric[:2] == "# "
+
+        assert self.fixer.NUM_LYRICS > 100


### PR DESCRIPTION
Passing in `-s` or `--sfw` will generate comments that are safe for work from random children's nursery rhymes and songs. This fulfills [issue #12](https://github.com/LeviBorodenko/lancer/issues/12).