### PR TITLE
Enhancement: Add useless comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A tool to turn your clean python code into a hideous (working) mess.
 ## Features
 1. Turn all comments into Pitbull lyrics 💃 (or optionally, something safe for work)
 2. Turn all your variable names into a mixture of animal sounds and horribly similar looking characters like "bark_bark_0OO0O". 🐶
-3. Add irritating white spaces. 
-4. Code still runs after all these _improvements_! 👷
+3. Add irritating white spaces.
+4. Add new, totally redundant comments.
+5. Code still runs after all these _improvements_! 👷
 
 
 ## Example
@@ -14,18 +15,21 @@ Before:
 ```python
 
 
-# function that adds two numbers
-def addition(a: int, b: int) -> int:
+# Function that finds the sum of a list of numbers
+def get_sum(nums: List[int]) -> int:
 
-    # find sum
-    result = a + b
+    sum = 0
 
-    # return the sum
-    return result
+    # Find the sum
+    for num in nums:
+        sum += num
 
+    # Return the sum
+    return sum
 
 if __name__ == '__main__':
-    print("Sum of 1 and 3 is %s" % addition(1, 3))
+    sum = get_sum([1, 3])
+    print(f"Sum of 1 and 3 is {sum}")
 
 ```
 
@@ -33,18 +37,23 @@ After:
 ```python
 
 
-# there's nothing like Miami's heat
-def quack_Il1Ι1l(squeak_squeak_IIΙΙlI: int, honk_honk_honk_aaαaα: int) -> int:
+# Hey baby, givin' it your all when you're dancin' on me
+def oink_oink_oink_IlΙlll (ribbit_ααaαα :List [int ])->int :
 
-    # Bada bing, bada boom
-    growl_growl_growl_ααaaα= squeak_squeak_IIΙΙlI  + honk_honk_honk_aaαaα
+    # Setting value of sum
+    sum =0
 
-    # Hey baby, givin' it your all when you're dancin' on me
-    return growl_growl_growl_ααaaα
+    # Forget about your boyfriend And meet me at the hotel room
+    for num in ribbit_ααaαα :
+        sum +=num
 
+        # Forget about your boyfriend And meet me at the hotel room
+    return sum
 
-if __name__ == '__main__':
-    print("Sum of 1 and 3 is %s" % quack_Il1Ι1l(1, 3))
+if __name__ =='__main__':
+    # Setting value of sum
+    sum =oink_oink_oink_IlΙlll ([1 ,3 ])
+    print (f"Sum of 1 and 3 is {sum}")
 
 ```
 
@@ -69,7 +78,7 @@ So if you have a python file at `./test.py`, you simply run `lance -f ./test.py`
 
 ## How does it work
 The key tool we use it the `tokenizer` standard module in python. It allows us to tokenize any python script which then in turn makes substituting comments and variable names fairly simple.
-Check out the source code for more details. 
+Check out the source code for more details.
 
 ## Contribute
 Bug reports, fixes and additional features are always welcome! Make sure to run the tests with `python setup.py test` and write your own for new features. Thanks.

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ def oink_oink_oink_IlΙlll (ribbit_ααaαα :List [int ])->int :
     # Setting value of sum
     sum =0
 
-    # Forget about your boyfriend And meet me at the hotel room
+    # Bada bing, bada boom
     for num in ribbit_ααaαα :
         sum +=num
 
-        # Forget about your boyfriend And meet me at the hotel room
+        # there's nothing like Miami's heat
     return sum
 
 if __name__ =='__main__':

--- a/src/lancer/entry.py
+++ b/src/lancer/entry.py
@@ -93,15 +93,6 @@ def lance(file: Path = "./file.py", sfw: bool = False, yolo: bool = False):
     comment_fixer = CommentFixer()
     comment_fixer.sfw = sfw
 
-    # # first fix comments
-    # comment_fixer.fix(file)
-
-    # # get the output file
-    # fixed_file = comment_fixer.__output__
-
-    # # applying variable fixer
-    # variable_fixer.fix(fixed_file)
-
     # First fix variables. This must be done before fixing comments as the
     # comment fixer adds comments referencing variable names.
     variable_fixer.fix(file)

--- a/src/lancer/entry.py
+++ b/src/lancer/entry.py
@@ -93,14 +93,24 @@ def lance(file: Path = "./file.py", sfw: bool = False, yolo: bool = False):
     comment_fixer = CommentFixer()
     comment_fixer.sfw = sfw
 
-    # first fix comments
-    comment_fixer.fix(file)
+    # # first fix comments
+    # comment_fixer.fix(file)
+
+    # # get the output file
+    # fixed_file = comment_fixer.__output__
+
+    # # applying variable fixer
+    # variable_fixer.fix(fixed_file)
+
+    # First fix variables. This must be done before fixing comments as the
+    # comment fixer adds comments referencing variable names.
+    variable_fixer.fix(file)
 
     # get the output file
-    fixed_file = comment_fixer.__output__
+    fixed_file = variable_fixer.__output__
 
-    # applying variable fixer
-    variable_fixer.fix(fixed_file)
+    # Now fix comments
+    comment_fixer.fix(fixed_file)
 
     # if yolo mode is true, substitute original
     if yolo:

--- a/src/lancer/fixers/comments.py
+++ b/src/lancer/fixers/comments.py
@@ -2,7 +2,7 @@ import logging
 from tokenize import COMMENT, NAME, NEWLINE, OP
 from typing import List, Sequence, Tuple
 from random import randint
-from lancer.utils import fix_wrapper, window
+from lancer.utils import fix_wrapper, isemptytype, window
 import pkg_resources
 
 __author__ = "Levi Borodenko"
@@ -127,7 +127,7 @@ class CommentFixer(object):
         token_iter = iter(tokens)
         for first, middle, last in window(token_iter, 3):
             if (
-                first[0] == NEWLINE and
+                isemptytype(first[0]) and
                 middle[0] == NAME and
                 last[0] == OP
                 and last[1] == "="

--- a/src/lancer/fixers/comments.py
+++ b/src/lancer/fixers/comments.py
@@ -1,12 +1,20 @@
 import logging
-from tokenize import COMMENT
+from tokenize import COMMENT, NAME, NEWLINE, OP
+from typing import List, Sequence, Tuple
 from random import randint
-from lancer.utils import fix_wrapper
+from lancer.utils import fix_wrapper, window
 import pkg_resources
 
 __author__ = "Levi Borodenko"
 __copyright__ = "Levi Borodenko"
 __license__ = "mit"
+
+
+# Tuple of (<token type>, (<token value>)
+# These tokens are returned by the fixer, and are suitable for being passed to
+# untokenize() to convert back to source code.
+LancerTokenType = Tuple[int, str]
+
 
 # setting up logger instance
 _logger = logging.getLogger(__name__)
@@ -60,6 +68,81 @@ class CommentFixer(object):
             # .rstrip to remove trailing whitespace
             return "# " + lyrics[random_index].rstrip()
 
+    def _substitute_comments_for_lyrics(
+        self, tokens: Sequence[LancerTokenType]
+    ) -> List[LancerTokenType]:
+        """
+        Substitute any comment tokens in the sequence tokens with random
+        lyrics.
+    
+        Arguments:
+            tokens  -- the list of tokens to substitute comments from.
+        
+        Return:
+            out_tokens  -- the new list of tokens after substitution.
+        """
+        out_tokens: List[LancerTokenType] = []
+
+        for token_type, token_val in tokens:
+            if token_type == COMMENT:
+                out_tokens.append((COMMENT, self._get_lyric()))
+            else:
+                out_tokens.append((token_type, token_val))
+
+        return out_tokens
+
+    def _add_pointless_variable_init_comments(
+        self, tokens: Sequence[LancerTokenType]
+    ) -> List[LancerTokenType]:
+        """
+        Add totally useless comments describing when variables are initialized.
+        E.g.    my_val = 3
+            ->
+                # Setting value of my_val
+                my_val = 3
+    
+        Arguments:
+            tokens  -- the current list of tokens for the source code.
+        
+        Return:
+            out_tokens  -- the new list of tokens after adding pointless
+                           comments.
+        """
+        # Identify initialized variables by looking for the following
+        # pattern:
+        #     first      NEWLINE        '\n'
+        #     middle     NAME           'my_var'
+        #     last       OP             '='
+        #
+        # Obviously this doesn't catch all initialized variables, but it will
+        # catch a decent number while keeping things simple.
+        out_tokens: List[LancerTokenType] = []
+
+        # Loop over token windows of size 3, inserting a pointless comment
+        # if the above pattern is spotted, and adding the middle token to the
+        # output list. Note that this means the first & last tokens are added
+        # seperately.
+        out_tokens.append(tokens[0])
+
+        token_iter = iter(tokens)
+        for first, middle, last in window(token_iter, 3):
+            if (
+                first[0] == NEWLINE and
+                middle[0] == NAME and
+                last[0] == OP
+                and last[1] == "="
+            ):
+                out_tokens.append(
+                    (COMMENT, "# Setting value of {}".format(middle[1]))
+                )
+                out_tokens.append((NEWLINE, "\n"))
+
+            out_tokens.append(middle)
+
+        out_tokens.append(tokens[-1])
+
+        return out_tokens
+
     @fix_wrapper
     def fix(self, tokens):
         """After decoration, it will take the file that you want to fix and
@@ -72,20 +155,14 @@ class CommentFixer(object):
             tokens -- the list of tokens from the file
 
         Returns:
-            result - list of tokens, but now with fixed comments
+            fixed_tokens - list of tokens, but now with fixed comments
         """
 
-        result = []
+        # Strip off the unneeded token elements.
+        stripped_tokens = [(token[0], token[1]) for token in tokens]
 
-        # iterating over tokens
-        for token_type, token_val, _, _, _, in tokens:
+        fixed_tokens = self._substitute_comments_for_lyrics(stripped_tokens)
 
-            # if token is a comment, substitute with a random lyric comment.
-            if token_type == COMMENT:
-                result.append(
-                    (COMMENT, self._get_lyric())
-                )
+        fixed_tokens = self._add_pointless_variable_init_comments(fixed_tokens)
 
-            else:
-                result.append((token_type, token_val))
-        return result
+        return fixed_tokens

--- a/src/lancer/fixers/comments.py
+++ b/src/lancer/fixers/comments.py
@@ -68,6 +68,19 @@ class CommentFixer(object):
             # .rstrip to remove trailing whitespace
             return "# " + lyrics[random_index].rstrip()
 
+    @staticmethod
+    def _is_comment_shebang_line(comment: str) -> bool:
+        """
+        Check if a comment is a shebang line.
+
+        Arguments:
+            comment -- the comment to check
+
+        Returns:
+            result - bool indicating if comment is a shebang
+        """
+        return comment.startswith("#!")
+
     def _substitute_comments_for_lyrics(
         self, tokens: Sequence[LancerTokenType]
     ) -> List[LancerTokenType]:
@@ -84,7 +97,10 @@ class CommentFixer(object):
         out_tokens: List[LancerTokenType] = []
 
         for token_type, token_val in tokens:
-            if token_type == COMMENT:
+            if (
+                token_type == COMMENT and
+                not self._is_comment_shebang_line(token_val)
+            ):
                 out_tokens.append((COMMENT, self._get_lyric()))
             else:
                 out_tokens.append((token_type, token_val))

--- a/src/lancer/fixers/variables.py
+++ b/src/lancer/fixers/variables.py
@@ -176,9 +176,6 @@ class VariableFixer(object):
         # get tokens
         first, middle, last = token_triple
 
-        if middle.string == "ret_val":
-            import pdb; pdb.set_trace()
-
         # check if "first" empty
         if isemptytype(first.type) and middle.type == NAME:
             # check if middle is not a build-in name.

--- a/src/lancer/fixers/variables.py
+++ b/src/lancer/fixers/variables.py
@@ -1,5 +1,5 @@
 import logging
-from tokenize import NAME, NL, DEDENT, INDENT
+from tokenize import NAME, NL, NEWLINE, DEDENT, INDENT
 from itertools import tee
 import random
 from lancer.utils import fix_wrapper, window, isbuildin
@@ -176,9 +176,11 @@ class VariableFixer(object):
         # get tokens
         first, middle, last = token_triple
 
-        # check if "first" empty
-        if first.type in [NL, INDENT, DEDENT] and middle.type == NAME:
+        if middle.string == "ret_val":
+            import pdb; pdb.set_trace()
 
+        # check if "first" empty
+        if first.type in [NL, NEWLINE, INDENT, DEDENT] and middle.type == NAME:
             # check if middle is not a build-in name.
             # For cases like:
             #   return ...all
@@ -187,7 +189,6 @@ class VariableFixer(object):
             # Things like:
             #   function(...)
             if not isbuildin(middle.string) and last.string != "(":
-
                 # write into dictionary
                 self._get_new_name(middle.string)
 

--- a/src/lancer/fixers/variables.py
+++ b/src/lancer/fixers/variables.py
@@ -1,8 +1,8 @@
 import logging
-from tokenize import NAME, NL, NEWLINE, DEDENT, INDENT
+from tokenize import NAME
 from itertools import tee
 import random
-from lancer.utils import fix_wrapper, window, isbuildin
+from lancer.utils import fix_wrapper, window, isbuildin, isemptytype
 import pkg_resources
 
 # import pkg_resources
@@ -180,7 +180,7 @@ class VariableFixer(object):
             import pdb; pdb.set_trace()
 
         # check if "first" empty
-        if first.type in [NL, NEWLINE, INDENT, DEDENT] and middle.type == NAME:
+        if isemptytype(first.type) and middle.type == NAME:
             # check if middle is not a build-in name.
             # For cases like:
             #   return ...all

--- a/src/lancer/utils.py
+++ b/src/lancer/utils.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 from functools import wraps
 from pathlib import Path
-from tokenize import tokenize, untokenize
+from tokenize import tokenize, untokenize, DEDENT, INDENT, NEWLINE, NL
 import sys
 import logging
 from collections import deque
@@ -139,6 +139,18 @@ def isbuildin(name: str) -> bool:
         return True
     else:
         return False
+
+def isemptytype(type: int) -> bool:
+    """
+    Check whether type is an 'empty' token type.
+
+    Arguments:
+        type {int} -- The token type
+
+    Returns:
+        bool -- True if type is an 'empty' type, False otherwise.
+    """
+    return type in [NL, NEWLINE, INDENT, DEDENT]
 
 def copy_and_delete(in_file:Path, out_file:Path):
     """[summary]


### PR DESCRIPTION
Two small enhancements/fixes:
- When variables are initialized, a completely useless comment is added stating that this has taken place.
- Avoid substituting shebang lines with pitbull lyrics, since pitbull rarely references valid interpreters in his lyrics

Example lancer input/output with this enhancement:

```
#!/usr/bin/env python3

from typing import List

def test_func(arg1: int, arg2: List[int]) -> float:
    """
    This is a test function
    """
    ret_val = 1.23
    other_var = 5

    print(arg1)
    for arg in arg2:
        print(arg)

    return ret_val

# This is a test comment.
print(test_func(2, [1, 2]))
print(test_func(4, [5, 6]))
```
->
```
#!/usr/bin/env python3

from typing import List 

def buzz_buzz_I11ΙlI (snort_snort_snort_aαaαa :int ,caw_caw_caw_ααααa :List [int ])->float :
    """
    This is a test function
    """
    # Setting value of snort_snort_OΟΟ0OO
    snort_snort_OΟΟ0OO =1.23 
    # Setting value of grrr_grrr_grrr_OΟΟOΟ0
    grrr_grrr_grrr_OΟΟOΟ0 =5 
    hoot_IΙIIll ,old_var =6 ,7 

    print (snort_snort_snort_aαaαa )
    for arg in caw_caw_caw_ααααa :
        print (arg )

    return snort_snort_OΟΟ0OO 

    # the bottom, simple as that
print (buzz_buzz_I11ΙlI (2 ,[1 ,2 ]))
print (buzz_buzz_I11ΙlI (4 ,[5 ,6 ]))
```